### PR TITLE
added list mode for display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,22 @@ INSTALLEXEC := sudo cp -f
 INSTALL := sudo cp -f
 endif
 
+UNAME := $(shell uname)
+
+ifeq ($(UNAME),Darwin)
+	OS_FLAG := OSX
+endif
+
 all: build test
 
 DESTDIR?=
 install: build
+ifeq ($(OS_FLAG),OSX)
+	$(INSTALLEXEC) "./aight" "${DESTDIR}/usr/local/bin/aight"
+else
 	$(INSTALLEXEC) "./aight" "${DESTDIR}/usr/bin/aight"
 	$(INSTALL) "./LICENSE" "${DESTDIR}/usr/share/licenses/aight/LICENSE"
+endif
 
 build:
 	dub build

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ trelloApiToken=your Trello token
 
 By default, `aight` will attempt to display multiple task lists (for example, multiple lists within a single Trello board) in ASCII table format, using the `listWidth` and `borderChar` settings and your terminal window width. If you would prefer to have multiple lists displayed one after the other, set `displayMode=list`.
 
+**Note:** While in `displayMode=list`, by default, tasks in a list will not respect `listWidth`. To force a width in list mode, set `listModePreserveWidth=true`.
+
 ### Task Providers
 
 Task providers are triggered based on a set of conditional attributes such as `matchDir` (to match the current working directory) or `matchRemote` (to match the upstream git URL). The first group to match the current conditions will be executed, and all others will be ignored. As an example, here is a group that will open a URL whenever `aight` is used in one of my repositories:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ trelloApiKey=a Trello API developer key
 trelloApiToken=your Trello token
 ```
 
+### Display Modes
+
+By default, `aight` will attempt to display multiple task lists (for example, multiple lists within a single Trello board) in ASCII table format, using the `listWidth` and `borderChar` settings and your terminal window width. If you would prefer to have multiple lists displayed one after the other, set `listMode=list`.
+
 ### Task Providers
 
 Task providers are triggered based on a set of conditional attributes such as `matchDir` (to match the current working directory) or `matchRemote` (to match the upstream git URL). The first group to match the current conditions will be executed, and all others will be ignored. As an example, here is a group that will open a URL whenever `aight` is used in one of my repositories:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ trelloApiToken=your Trello token
 
 ### Display Modes
 
-By default, `aight` will attempt to display multiple task lists (for example, multiple lists within a single Trello board) in ASCII table format, using the `listWidth` and `borderChar` settings and your terminal window width. If you would prefer to have multiple lists displayed one after the other, set `listMode=list`.
+By default, `aight` will attempt to display multiple task lists (for example, multiple lists within a single Trello board) in ASCII table format, using the `listWidth` and `borderChar` settings and your terminal window width. If you would prefer to have multiple lists displayed one after the other, set `displayMode=list`.
 
 ### Task Providers
 

--- a/source/print.d
+++ b/source/print.d
@@ -120,7 +120,7 @@ class Printer {
     }
 
     string[] printLists(List[] lists) {
-      bool isList = (0 == cmp(this.displayMode, "list"));
+      bool isList = ("list" == this.displayMode);
 
     	int size = 0;
     	foreach (list; lists) {
@@ -135,7 +135,7 @@ class Printer {
 
     		if (lists.length == 1) {
     			print = rows;
-        } else if (0 == cmp(this.displayMode, "list")) {
+        } else if (isList) {
           print ~= rows;
         } else {
           for (int i = 0; i < rows.length; i++) {

--- a/source/print.d
+++ b/source/print.d
@@ -67,7 +67,7 @@ class Printer {
 
     string[] printList(List list) {
 
-      if (0 == cmp(this.displayMode, "list")) {
+      if ("list" == this.displayMode) {
         return this.printListWithoutTable(list);
       } else {
         return this.printList(list, this.listWidth * 2);

--- a/source/print.d
+++ b/source/print.d
@@ -17,7 +17,7 @@ class Printer {
 
     int listWidth;
 
-    string listMode;
+    string displayMode;
 
     this(ConfigGroup conf) {
         this.conf = conf;
@@ -28,7 +28,7 @@ class Printer {
 
         this.listWidth = to!int(conf.setting("listWidth", "40"));
 
-        this.listMode = conf.setting("listMode", "table");
+        this.displayMode = conf.setting("displayMode", "table");
     }
 
     /**
@@ -101,7 +101,7 @@ class Printer {
     		string[] rows = printList(list, size);
     		if (print.length == 0) {
     			print = rows;
-        } else if (0 == cmp(this.listMode, "list")) {
+        } else if (0 == cmp(this.displayMode, "list")) {
           for (int i = 0; i < rows.length; i++) {
             print[x*i] = rows[i];
           }

--- a/source/print.d
+++ b/source/print.d
@@ -72,13 +72,20 @@ class Printer {
 
       if (0 == cmp(this.displayMode, "list")) {
         //writeln("list.tasks.length = ", list.tasks.length);
-        return this.printList(list, to!int(list.tasks.length));
+        return this.printListWithoutTable(list);
       } else {
         return this.printList(list, this.listWidth * 2);
       }
 
     }
 
+    /**
+     * Format a list to a given height to be
+     * printed in a table.
+     *
+     * @param list          The List to be formatted.
+     * @param height        The height of the table.
+     */
     string[] printList(List list, int height) {
 	    string[] render;
 	    render ~= getRowOuter(listWidth);
@@ -98,8 +105,26 @@ class Printer {
 	    return render;
     }
 
+    /**
+     * Formats a list for display
+     * without table formatting.
+     *
+     * @param list          The List to be formatted.
+     */
+    string[] printListWithoutTable(List list) {
+      string[] render;
+      render ~= list.name;
+      render ~= getRowOuter(listWidth);
+      foreach (task; list.tasks) {
+        render ~= format("%s: %s", task.humanId, task.name); // TODO: implement listModePreserveWidth checking
+      }                                                      // possibly look at D string formatting functionality
+      render ~= " ";
+
+      return render;
+    }
+
     string[] printLists(List[] lists) {
-      bool isList = 0 == cmp(this.displayMode, "list");
+      bool isList = (0 == cmp(this.displayMode, "list"));
 
     	int size = 0;
     	foreach (list; lists) {
@@ -122,7 +147,7 @@ class Printer {
         } else if (0 == cmp(this.displayMode, "list")) {
           print.length = rows.length * lists.length;
           for (int i = 0; i < rows.length; i++) {
-            if (rows[i].empty) continue;
+            if (rows[i]) continue;
             print[x*i + i] = rows[i];
           }
         } else {

--- a/source/print.d
+++ b/source/print.d
@@ -10,12 +10,14 @@ import std.conv;
 class Printer {
 
     ConfigGroup conf;
-    
+
     string bchar;
     string hbchar;
     string vbchar;
 
     int listWidth;
+
+    string listMode;
 
     this(ConfigGroup conf) {
         this.conf = conf;
@@ -25,6 +27,8 @@ class Printer {
         this.vbchar = conf.setting("borderCharVertical", "|");
 
         this.listWidth = to!int(conf.setting("listWidth", "40"));
+
+        this.listMode = conf.setting("listMode", "table");
     }
 
     /**
@@ -57,7 +61,7 @@ class Printer {
     string getRowContent(int width, string content) {
         if (content.length > width - 4)
             content = format("%-.*s...", width - 7, content);
-        
+
         return format("%s %-*s %s", vbchar, width - 4, content, vbchar);
     }
 
@@ -92,13 +96,20 @@ class Printer {
     	}
 
     	string[] print;
-    	foreach (list; lists) {
+
+    	foreach (x, list; lists) {
     		string[] rows = printList(list, size);
-    		if (print.length == 0)
+    		if (print.length == 0) {
     			print = rows;
-            else for (int i = 0; i < rows.length; i++) {
-    			print[i] ~= rows[i][1 .. $];
-    		}
+        } else if (0 == cmp(this.listMode, "list")) {
+          for (int i = 0; i < rows.length; i++) {
+            print[x*i] = rows[i];
+          }
+        } else {
+          for (int i = 0; i < rows.length; i++) {
+      			print[i] ~= rows[i][1 .. $];
+      		}
+        }
     	}
 
     	return print;

--- a/source/print.d
+++ b/source/print.d
@@ -131,12 +131,7 @@ class Printer {
     	string[] print;
 
     	foreach (x, list; lists) {
-        string[] rows;
-        if (isList) {
-          rows = printList(list);
-        } else {
-          rows = printList(list, size);
-        }
+        string[] rows = isList ? printList(list) : printList(list, size);
 
     		if (lists.length == 1) {
     			print = rows;

--- a/source/print.d
+++ b/source/print.d
@@ -7,6 +7,9 @@ import std.array;
 import std.string;
 import std.conv;
 
+// FOR DEBUGGING
+import std.stdio;
+
 class Printer {
 
     ConfigGroup conf;
@@ -66,7 +69,14 @@ class Printer {
     }
 
     string[] printList(List list) {
+
+      if (0 == cmp(this.displayMode, "list")) {
+        //writeln("list.tasks.length = ", list.tasks.length);
+        return this.printList(list, to!int(list.tasks.length));
+      } else {
         return this.printList(list, this.listWidth * 2);
+      }
+
     }
 
     string[] printList(List list, int height) {
@@ -89,6 +99,8 @@ class Printer {
     }
 
     string[] printLists(List[] lists) {
+      bool isList = 0 == cmp(this.displayMode, "list");
+
     	int size = 0;
     	foreach (list; lists) {
     		if (list.tasks.length > size)
@@ -98,12 +110,20 @@ class Printer {
     	string[] print;
 
     	foreach (x, list; lists) {
-    		string[] rows = printList(list, size);
+        string[] rows;
+        if (isList) {
+          rows = printList(list);
+        } else {
+          rows = printList(list, size);
+        }
+
     		if (print.length == 0) {
     			print = rows;
         } else if (0 == cmp(this.displayMode, "list")) {
+          print.length = rows.length * lists.length;
           for (int i = 0; i < rows.length; i++) {
-            print[x*i] = rows[i];
+            if (rows[i].empty) continue;
+            print[x*i + i] = rows[i];
           }
         } else {
           for (int i = 0; i < rows.length; i++) {

--- a/source/print.d
+++ b/source/print.d
@@ -7,9 +7,6 @@ import std.array;
 import std.string;
 import std.conv;
 
-// FOR DEBUGGING
-import std.stdio;
-
 class Printer {
 
     ConfigGroup conf;
@@ -71,7 +68,6 @@ class Printer {
     string[] printList(List list) {
 
       if (0 == cmp(this.displayMode, "list")) {
-        //writeln("list.tasks.length = ", list.tasks.length);
         return this.printListWithoutTable(list);
       } else {
         return this.printList(list, this.listWidth * 2);
@@ -142,14 +138,10 @@ class Printer {
           rows = printList(list, size);
         }
 
-    		if (print.length == 0) {
+    		if (lists.length == 1) {
     			print = rows;
         } else if (0 == cmp(this.displayMode, "list")) {
-          print.length = rows.length * lists.length;
-          for (int i = 0; i < rows.length; i++) {
-            if (rows[i]) continue;
-            print[x*i + i] = rows[i];
-          }
+          print ~= rows;
         } else {
           for (int i = 0; i < rows.length; i++) {
       			print[i] ~= rows[i][1 .. $];

--- a/source/providers/trello.d
+++ b/source/providers/trello.d
@@ -28,7 +28,7 @@ class TrelloTaskProvider : TaskProvider {
     /**
      * Send an authenticated request to a particular
      * endpoint of the Trello API.
-     * 
+     *
      * @param endpoint          The endpoint to send the request to.
      */
     char[] request(string endpoint) {
@@ -57,7 +57,7 @@ class TrelloTaskProvider : TaskProvider {
         list.tasks = tasks;
         return list;
     }
-    
+
     /**
      * Get an array of lists of the Trello board.
      */


### PR DESCRIPTION
* added `displayMode` preference
* `displayMode=list` will display tasks in a single column list
* default is `displayMode=table`
* closes #12, with the exception of `listModePreserveWidth`, which is not implemented yet.
* all documentation updated
* need to see if `displayMode` can be overwritten selector-by-selector, or if that functionality needs implemented
* **also:** updated makefile to better support mac installation