### PR TITLE
random printer fixes

### DIFF
--- a/source/print.d
+++ b/source/print.d
@@ -138,8 +138,9 @@ class Printer {
         } else if (isList) {
           print ~= rows;
         } else {
+          print.length = rows.length;
           for (int i = 0; i < rows.length; i++) {
-      			print[i] ~= rows[i][1 .. $];
+      			print[i] ~= rows[i][(x > 0 ? 1 : 0) .. $];
       		}
         }
     	}


### PR DESCRIPTION
Fixes a range exception due to referencing `print[i]` beyond the length of an array, and adds back the first border column of table characters.